### PR TITLE
Resolve included files during Analyzer preprocessing

### DIFF
--- a/crates/analyzer-core/benches/lexer.rs
+++ b/crates/analyzer-core/benches/lexer.rs
@@ -10,7 +10,7 @@ use logos::Span;
 fn baseline(input: String) -> Vec<char> { input.chars().into_iter().collect() }
 
 fn basic(input: String) -> Vec<(Token, Span)> {
-	let db = Database::default();
+	let db = Database::new(|base, _| Ok(base.into()));
 	let buf = Buffer::new(&db, input);
 	let file_id = FileId::new(&db, "foo".to_string());
 	let lexed = lex(&db, file_id, buf);

--- a/crates/analyzer-core/src/base_abstractions.rs
+++ b/crates/analyzer-core/src/base_abstractions.rs
@@ -15,6 +15,10 @@ pub struct FileId {
 #[salsa::accumulator]
 pub struct Diagnostics(Diagnostic);
 
+/// An accumulated collection of dependencies typically keyed by their source [`FileId`].
+#[salsa::accumulator]
+pub struct IncludedDependencies(IncludedDependency);
+
 #[derive(Clone, PartialEq, Eq)]
 pub enum Severity {
 	Info,
@@ -29,4 +33,14 @@ pub struct Diagnostic {
 	pub location: std::ops::Range<usize>,
 	pub severity: Severity,
 	pub message: String,
+}
+
+/// Represents an included dependency.
+#[derive(Clone, PartialEq, Eq)]
+pub struct IncludedDependency {
+	/// The [`FileId`] of the included target.
+	pub file: FileId,
+
+	/// The path of the included target.
+	pub include_path: String,
 }

--- a/crates/analyzer-core/src/base_abstractions.rs
+++ b/crates/analyzer-core/src/base_abstractions.rs
@@ -38,9 +38,9 @@ pub struct Diagnostic {
 /// Represents an included dependency.
 #[derive(Clone, PartialEq, Eq)]
 pub struct IncludedDependency {
-	/// The [`FileId`] of the included target.
-	pub file: FileId,
+	/// The [`FileId`] identifying the dependency.
+	pub file_id: FileId,
 
-	/// The path of the included target.
-	pub include_path: String,
+	/// A flag indicating the resolved state of the dependency.
+	pub is_resolved: bool,
 }

--- a/crates/analyzer-core/src/lib.rs
+++ b/crates/analyzer-core/src/lib.rs
@@ -223,7 +223,7 @@ pub fn lex(db: &dyn crate::Db, file_id: FileId, buf: Buffer) -> LexedBuffer {
 }
 
 #[salsa::tracked(return_ref)]
-pub fn preprocess<'a>(db: &dyn crate::Db, fs: Fs, file_id: FileId) -> Option<Vec<(FileId, Token, Span)>> {
+pub fn preprocess(db: &dyn crate::Db, fs: Fs, file_id: FileId) -> Option<Vec<(FileId, Token, Span)>> {
 	let mut pp = PreprocessorState::new(
 		|path: &str| {
 			// Return a `FileId` with an absolute path resolved relative to the file being preprocessed. If the path

--- a/crates/analyzer-core/src/lib.rs
+++ b/crates/analyzer-core/src/lib.rs
@@ -113,7 +113,7 @@ impl Analyzer {
 
 	/// Retrieves the included dependencies for a given source [`FileId`].
 	pub fn include_dependencies(&self, id: FileId) -> Vec<IncludedDependency> {
-		preprocess::accumulated::<IncludedDependencies>(&self.db, self.fs.unwrap(), id)
+		self.fs.map(|fs| preprocess::accumulated::<IncludedDependencies>(&self.db, fs, id)).unwrap_or_default()
 	}
 
 	pub fn delete(&mut self, uri: &str) -> Option<()> {

--- a/crates/analyzer-core/src/preprocessor.rs
+++ b/crates/analyzer-core/src/preprocessor.rs
@@ -248,7 +248,7 @@ pub struct PreprocessorState<'a> {
 	to_id: Box<dyn FnMut(&str) -> FileId + 'a>,
 }
 
-type LexFn<'a> = dyn FnMut(FileId, &str) -> Option<&'a Vec<(Token, Span)>> + 'a;
+type LexFn<'a> = dyn FnMut(FileId) -> Option<&'a Vec<(Token, Span)>> + 'a;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 enum VertexState {
@@ -257,7 +257,7 @@ enum VertexState {
 }
 
 impl<'a> PreprocessorState<'a> {
-	pub fn new<Idlyzer: FnMut(&str) -> FileId + 'a, FLex: FnMut(FileId, &str) -> Option<&'a Vec<(Token, Span)>> + 'a>(
+	pub fn new<Idlyzer: FnMut(&str) -> FileId + 'a, FLex: FnMut(FileId) -> Option<&'a Vec<(Token, Span)>> + 'a>(
 		to_id: Idlyzer,
 		lex: FLex,
 	) -> PreprocessorState<'a> {
@@ -294,7 +294,7 @@ impl<'a> PreprocessorState<'a> {
 						let file_id = (self.to_id)(&path); // TODO: path resolution here or in to_id
 						if self.state.get(&file_id).is_some() {
 							self.error(id, span, recursive_err);
-						} else if let Some(tokens) = (self.lex)(file_id, &path) as Option<&Vec<(Token, Span)>> {
+						} else if let Some(tokens) = (self.lex)(file_id) as Option<&Vec<(Token, Span)>> {
 							self.state.insert(file_id, VertexState::Open);
 							input.reserve(input.len() + tokens.len());
 							tokens
@@ -568,8 +568,8 @@ mod test {
 	}
 
 	fn preprocess(s: &str, errors: &mut Vec<String>) -> Vec<Token> {
-		let db = Database::default();
-		let mut pp = PreprocessorState::new(|path| FileId::new(&db, path.into()), |_, _| unreachable!());
+		let db = Database::new(|base, _| Ok(base.into()));
+		let mut pp = PreprocessorState::new(|path| FileId::new(&db, path.into()), |_| unreachable!());
 
 		let test_id = FileId::new(&db, "<test-code>.p4".into());
 		let input = Buffer::new(&db, s.into());
@@ -651,7 +651,7 @@ mod test {
 
 	#[test]
 	fn complex_conditions() {
-		let pp = PreprocessorState::new(|_| unimplemented!(), |_, _| unimplemented!());
+		let pp = PreprocessorState::new(|_| unimplemented!(), |_| unimplemented!());
 
 		let expr = expression("1 - ( 2 ) + 1").unwrap().1;
 		assert_eq!(pp.interpret_pp_expr(&expr), Some(0));

--- a/crates/analyzer-core/tests/lexer.rs
+++ b/crates/analyzer-core/tests/lexer.rs
@@ -6,7 +6,7 @@ use lexer::*;
 use pretty_assertions::assert_eq;
 
 fn lex_str(s: &str) -> Vec<Token> {
-	let db = Database::default();
+	let db = Database::new(|base, _| Ok(base.into()));
 	let buf = Buffer::new(&db, s.to_string());
 	let file_id = FileId::new(&db, "foo.p4".to_string());
 	let lexed = lex(&db, file_id, buf);

--- a/crates/analyzer-host/src/fs.rs
+++ b/crates/analyzer-host/src/fs.rs
@@ -1,5 +1,4 @@
 use analyzer_abstractions::{
-	async_trait::async_trait,
 	fs::EnumerableFileSystem,
 	lsp_types::{request::Request, TextDocumentIdentifier, Url},
 	tracing::error,
@@ -24,7 +23,6 @@ impl LspEnumerableFileSystem {
 	pub fn new(request_manager: RequestManager) -> Self { Self { request_manager } }
 }
 
-// #[async_trait]
 impl EnumerableFileSystem for LspEnumerableFileSystem {
 	fn enumerate_folder<'a>(
 		&'a self,

--- a/crates/analyzer-host/src/lsp/analyzer.rs
+++ b/crates/analyzer-host/src/lsp/analyzer.rs
@@ -1,6 +1,6 @@
 use std::cell::RefMut;
 
-use analyzer_abstractions::lsp_types::TextDocumentIdentifier;
+use analyzer_abstractions::{lsp_types::TextDocumentIdentifier, BoxFuture};
 use analyzer_core::base_abstractions::FileId;
 
 pub(crate) type ParsedUnit = FileId;
@@ -8,8 +8,8 @@ pub(crate) type ParsedUnit = FileId;
 pub(crate) trait Analyzer {
 	fn unwrap(&self) -> RefMut<analyzer_core::Analyzer>;
 
-	fn parse_text_document_contents(&self, document_identifier: TextDocumentIdentifier, contents: String)
-		-> ParsedUnit;
+	fn parse_text_document_contents<'a>(&'a self, document_identifier: TextDocumentIdentifier, contents: String)
+		-> BoxFuture<'a, ParsedUnit>;
 }
 
 pub(crate) type AnyAnalyzer = Box<dyn Analyzer + Send + Sync + 'static>;

--- a/crates/analyzer-host/src/lsp/analyzer.rs
+++ b/crates/analyzer-host/src/lsp/analyzer.rs
@@ -1,15 +1,16 @@
-use std::cell::RefMut;
+use std::{cell::RefMut, sync::Arc};
 
-use analyzer_abstractions::{lsp_types::TextDocumentIdentifier, BoxFuture};
 use analyzer_core::base_abstractions::FileId;
+
+use super::workspace::File;
 
 pub(crate) type ParsedUnit = FileId;
 
 pub(crate) trait Analyzer {
 	fn unwrap(&self) -> RefMut<analyzer_core::Analyzer>;
 
-	fn parse_text_document_contents<'a>(&'a self, document_identifier: TextDocumentIdentifier, contents: String)
-		-> BoxFuture<'a, ParsedUnit>;
+	/// Enqueues a [`File`] for background analyzing.
+	fn background_analyze(&self, file: Arc<File>);
 }
 
 pub(crate) type AnyAnalyzer = Box<dyn Analyzer + Send + Sync + 'static>;

--- a/crates/analyzer-host/src/lsp/analyzer.rs
+++ b/crates/analyzer-host/src/lsp/analyzer.rs
@@ -1,16 +1,10 @@
-use std::{cell::RefMut, sync::Arc};
-
 use analyzer_core::base_abstractions::FileId;
-
-use super::workspace::File;
+use analyzer_abstractions::lsp_types::Url;
 
 pub(crate) type ParsedUnit = FileId;
 
-pub(crate) trait Analyzer {
-	fn unwrap(&self) -> RefMut<analyzer_core::Analyzer>;
-
-	/// Enqueues a [`File`] for background analyzing.
-	fn background_analyze(&self, file: Arc<File>);
+pub(crate) trait BackgroundLoad {
+	fn load(&self, file_path: Url);
 }
 
-pub(crate) type AnyAnalyzer = Box<dyn Analyzer + Send + Sync + 'static>;
+pub(crate) type AnyBackgroundLoad = dyn BackgroundLoad + Send + Sync;

--- a/crates/analyzer-host/src/lsp/workspace.rs
+++ b/crates/analyzer-host/src/lsp/workspace.rs
@@ -71,7 +71,7 @@ impl WorkspaceManager {
 	/// files may be made in contexts in which no workspace folders were opened. If this is the case, then the file will
 	/// be retrieved relative to the 'catch-all' workspace which is not indexed.
 	///
-	/// The overall state of the file can be determined from its [`File::get_compiled_unit`] method which will
+	/// The overall state of the file can be determined from its [`File::get_parsed_unit`] method which will
 	/// inform its final state.
 	pub fn get_file(&self, uri: Url) -> Arc<File> {
 		fn is_descendant_path(base: &Url, target: &Url) -> bool {
@@ -335,7 +335,7 @@ async fn background_analyze(
 						// parsed unit.
 						if !file.is_open_in_ide() {
 							let parsed_unit =
-								analyzer.parse_text_document_contents(file.document_identifier.clone(), contents);
+								analyzer.parse_text_document_contents(file.document_identifier.clone(), contents).await;
 
 							file.set_parsed_unit(parsed_unit, None);
 						}

--- a/crates/analyzer-host/src/lsp_impl/state.rs
+++ b/crates/analyzer-host/src/lsp_impl/state.rs
@@ -184,11 +184,10 @@ impl State {
 			analyzer.update(file_id, text);
 			analyzer.preprocessed(file_id);
 
-			let includes = analyzer.include_dependencies(file_id);
-
+			// Return the FileId and the set of unresolved included paths.
 			(
 				file_id,
-				includes
+				analyzer.include_dependencies(file_id)
 					.iter()
 					.filter(|include| !include.is_resolved)
 					.map(|include| Url::parse(&analyzer.path(include.file_id)).unwrap())

--- a/crates/analyzer-host/src/lsp_impl/state.rs
+++ b/crates/analyzer-host/src/lsp_impl/state.rs
@@ -216,17 +216,16 @@ impl State {
 
 									file.set_parsed_unit(file_id, None);
 
-									// If the file contains dependencies, then ensure they are also resolved. To do this, we'll get
-									// the file from the Workspace Manager. If the file has not yet been resolved then it will also
-									// come through this background process.
+									// If the file contains dependencies, then ensure that they are also resolved. To do this,
+									// we'll get the file from the Workspace Manager. If the file has not yet been resolved then
+									// it will also come through this background process.
 									if file_includes.is_empty() {
 										return;
 									}
 
 									let file_include_resolvers = file_includes.iter().map(|include| async {
-										let file = workspace_manager.get_file(
-											Url::parse(&format!("file://{}", &include.include_path)).unwrap(),
-										);
+										let file =
+											workspace_manager.get_file(Url::parse(&include.include_path).unwrap());
 
 										// We don't care about the result only that it recurses through this process.
 										let _ = file.get_parsed_unit().await;


### PR DESCRIPTION
This PR addresses #15 by accumulating included file paths during preprocessing, and then resolving them as part of the background processing of files. Because included paths are resolved via the Workspaces, the process is entirely recursive.

### Tasks
- [x] 1. Consider how best to resolve included paths. We generally only ever want to use absolute paths (especially when used alongside a `FileId`).
- [ ] ~~2. Consider how best to report errors (i.e., if a file is physically not present on the underlying file system).~~
- [ ] ~~3. Think about what happens when an `'#include ...'` line get removed.~~
- [x] 4. Ensure that we resolve included dependencies between changes.

### Task Notes
1. While not using on demand inputs directly, I have used the [`on_demand_inputs` page](https://salsa-rs.netlify.app/common_patterns/on_demand_inputs.html) as inspiration, I have extended the `Db` trait with a new `resolve_path(...)` function that will return an absolute path by joining a given base, and a target path. This function is then used by the `preprocess(...)` function when computing a new `FileId` for an included path. This keeps all referenced paths known to the FileSystem in an absolute form, and (more importantly) unique when stored as `FileId`s in the Salsa database.

2. The `Analyzer` will report a missing file through its diagnostics. This is all done separately to the workspace manager which will set an `Err(IndexError::NotFound)` against the `File` instance.

3. We don't need to worry about this anymore. If an `'#include ...'` line is removed then the accumulated dependencies for the associated `FileId` simply won't include it anymore as part of its new Salsa revision. It will still be present in the Workspace Manager, but that is OK. The Workspace Manager mirrors what is on the 'disk' rather than what the Analyzer currently needs to parse.

4. The `Analyzer::preprocessed(...)` function will now call a new `require_fn` for any `IncludeDependency` for which `is_resolved` is false. This results in the dependency being loaded in the background and set in the Analyzer. 

### Future Work
Currently the preprocessor only considers _relative_ paths, and it also doesn't consider the quotation style. As such, an include in the form `'#include "core.p4"'` will be resolved relative to the file that contains it. This is correct behavior. Future work is required to support the angle bracket quotation style, and in turn, support for multiple paths while resolving. As outlined in the P4_16 specification, the quotation style simply determines the order in which the preprocessor will need to consider these file paths: `'"..."'` using the relative path ahead of any additional include path list, and `'<...>'` using the relative path last.