### PR TITLE
Fix broken `main`

### DIFF
--- a/crates/analyzer-abstractions/src/futures_extensions/async_extensions.rs
+++ b/crates/analyzer-abstractions/src/futures_extensions/async_extensions.rs
@@ -73,9 +73,9 @@ impl AsyncPool {
 	}
 
 	pub fn stop() {
-		let (_, receiver) = WORK_CHANNEL.with(|c| c.borrow().clone());
+		let (sender, _) = WORK_CHANNEL.with(|c| c.borrow().clone());
 
-		receiver.close();
+		sender.close();
 	}
 
 	pub fn spawn_work<T>(future: T)

--- a/crates/analyzer-host/src/lib.rs
+++ b/crates/analyzer-host/src/lib.rs
@@ -115,37 +115,39 @@ impl AnalyzerHost {
 		requests_receiver: Receiver<Message>,
 		cancel_token: Arc<CancellationToken>,
 	) -> Result<(), OperationCanceled> {
-		let mut protocol_machine = LspProtocolMachine::new(self.trace_value.clone(), request_manager, file_system);
+		{ // Scope: for `protocol_machine`.
+			let mut protocol_machine = LspProtocolMachine::new(self.trace_value.clone(), request_manager, file_system);
 
-		while protocol_machine.is_active() && !cancel_token.is_canceled() {
-			match requests_receiver.recv().await {
-				Ok(message) => {
-					if cancel_token.is_canceled() {
-						break;
-					}
+			while protocol_machine.is_active() && !cancel_token.is_canceled() {
+				match requests_receiver.recv().await {
+					Ok(message) => {
+						if cancel_token.is_canceled() {
+							break;
+						}
 
-					let request_message_span = info_span!("[Message]", message = format!("{}", message));
+						let request_message_span = info_span!("[Message]", message = format!("{}", message));
 
-					async {
-						match protocol_machine.process_message(Arc::new(message)).await {
-							Ok(response_message) => {
-								if let Some(Message::Response(_)) = &response_message {
-									self.sender.send(response_message.unwrap()).await.unwrap();
+						async {
+							match protocol_machine.process_message(Arc::new(message)).await {
+								Ok(response_message) => {
+									if let Some(Message::Response(_)) = &response_message {
+										self.sender.send(response_message.unwrap()).await.unwrap();
+									}
+								}
+								Err(err) => {
+									error!("Protocol Error: {}", &err.to_string());
 								}
 							}
-							Err(err) => {
-								error!("Protocol Error: {}", &err.to_string());
-							}
 						}
+						.instrument(request_message_span)
+						.await;
 					}
-					.instrument(request_message_span)
-					.await;
-				}
-				Err(err) => {
-					error!("Unexpected error receiving request or notification: {:?}", err);
+					Err(err) => {
+						error!("Unexpected error receiving request or notification: {:?}", err);
+					}
 				}
 			}
-		}
+		} // End Scope
 
 		self.sender.close();
 		self.receiver.close();

--- a/crates/analyzer-host/src/lsp/workspace.rs
+++ b/crates/analyzer-host/src/lsp/workspace.rs
@@ -114,12 +114,6 @@ impl WorkspaceManager {
 
 		progress.end(None).await.unwrap();
 	}
-
-	pub fn close(&self) {
-		for workspace in self.workspaces.clone().into_iter() {
-			workspace.1.close();
-		}
-	}
 }
 
 impl<'a> IntoIterator for &'a WorkspaceManager {
@@ -205,8 +199,6 @@ impl Workspace {
 
 		write_files(self, &document_identifiers);
 	}
-
-	pub fn close(&self) { self.parse_sender.close(); }
 }
 
 impl Display for Workspace {

--- a/crates/analyzer-host/src/lsp_impl/shutting_down.rs
+++ b/crates/analyzer-host/src/lsp_impl/shutting_down.rs
@@ -21,7 +21,6 @@ pub(crate) fn create_dispatcher() -> LspServerStateDispatcher {
 }
 
 /// Responds to an 'exit' notification from the LSP client.
-async fn on_exit(_: LspServerState, _: (), state: Arc<AsyncRwLock<State>>) -> HandlerResult<()> {
-	state.write().await.workspaces().close();
+async fn on_exit(_: LspServerState, _: (), _: Arc<AsyncRwLock<State>>) -> HandlerResult<()> {
 	Ok(())
 }

--- a/crates/analyzer-host/src/lsp_impl/state.rs
+++ b/crates/analyzer-host/src/lsp_impl/state.rs
@@ -231,6 +231,12 @@ impl State {
 	}
 }
 
+impl Drop for State {
+	fn drop(&mut self) {
+			self.background_parse_channel.0.close();
+	}
+}
+
 #[derive(Clone)]
 struct BackgroundQueue(Sender<Url>);
 


### PR DESCRIPTION
This PR fixes the break that has been introduced into `main` from the merging of #20 and #24.

I forgot to rebase my branch (via #24) and GitHub showed no conflicts. However, some of the code in #20 became broken because I refactored await some of the dependent API. This PR fixes that.

The main change is that Workspaces can no longer close the underlying channel used to schedule background loading. Instead this is all now achieved through a custom trait. To close the underlying channel used by the background loader, I've implemented `Drop` for `State` instead and closed the channel when `State` is dropped.