### PR TITLE
Version control added to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
 	"name": "p4-analyzer-sources",
 	"description": "Package sources for the P4 Analyzer.",
 	"private": true,
-	"publisher": "P4.org",
 	"scripts": {
 		"prebuild": "cargo build && wasm-pack build --target nodejs crates/p4-analyzer-wasm",
 		"build": "run-script-os",
@@ -23,9 +22,9 @@
 		"@nrwl/workspace": "~15.5",
 		"@types/node": "^16",
 		"@types/vscode": "^1",
+		"@vscode/vsce": "^2.19.0",
 		"esbuild": "latest",
 		"run-script-os": "^1.1.6",
-		"typescript": "^4",
-		"@vscode/vsce": "^2.19.0"
+		"typescript": "^4"
 	}
 }

--- a/packages/p4-analyzer-vscode/git_commit.js
+++ b/packages/p4-analyzer-vscode/git_commit.js
@@ -1,0 +1,14 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+// Get the current Git commit
+const commit = execSync('git rev-parse --short HEAD').toString().trim();
+
+// Read the package.json file
+const packageJson = JSON.parse(fs.readFileSync('package.json'));
+
+// Update the version field with the commit
+packageJson.version = '0.0.1-' + commit.slice(0, 8);
+
+// Write the modified package.json file
+fs.writeFileSync('package.json', JSON.stringify(packageJson, null, 2));

--- a/packages/p4-analyzer-vscode/package.json
+++ b/packages/p4-analyzer-vscode/package.json
@@ -1,111 +1,111 @@
 {
-	"name": "p4-analyzer-vscode",
-	"version": "0.0.0",
-	"displayName": "P4 Analyzer",
-	"description": "P4 language support for Visual Studio Code",
-	"private": true,
-	"scripts": {
-		"vscode:prepublish": "npm run build-base -- --minify",
-		"bundle-wasm-analyzer": "run-script-os",
-		"bundle-wasm-analyzer:nix": "mkdir -p ./node_modules/p4-analyzer && cp -R ../p4-analyzer/package.json ../p4-analyzer/lib ./node_modules/p4-analyzer",
-		"bundle-wasm-analyzer:windows": "mkdir .\\node_modules\\p4-analyzer & xcopy /E /Y ..\\p4-analyzer\\package.json .\\node_modules\\p4-analyzer\\ & xcopy /E /Y ..\\p4-analyzer\\lib .\\node_modules\\p4-analyzer\\lib\\",
-		"build-base": "esbuild ./src/index.ts --bundle --outfile=lib/index.js --external:vscode --format=cjs --platform=node",
-		"prebuild-base": "npm run bundle-wasm-analyzer",
-		"build": "npm run build-base -- --sourcemap",
-		"build-windows": "npm run build-base -- --sourcemap",
-		"build-nix": "npm run build-base -- --sourcemap",
-		"build-watch": "npm run build-base -- --sourcemap --watch",
-		"package": "npx vsce package"
-	},
-	"icon": "p4.png",
-	"releaseTag": null,
-	"publisher": "P4.org",
-	"repository": {
-		"url": "https://github.com/p4lang/p4analyzer.git",
-		"type": "git"
-	},
-	"homepage": "https://www.p4.org",
-	"license": "Apache-2.0",
-	"keywords": [
-		"p4"
-	],
-	"categories": [
-		"Programming Languages"
-	],
-	"engines": {
-		"vscode": "^1.73.0"
-	},
-	"main": "./lib/index.js",
-	"activationEvents": [
-		"onLanguage:p4"
-	],
-	"contributes": {
-		"configuration": [
-			{
-				"title": "P4 Analyzer",
-				"properties": {
-					"p4-analyzer.server.absoluteServerPath": {
-						"type": "string",
-						"scope": "window",
-						"default": null,
-						"markdownDescription": "Specifies the absolute path to a P4 Analyzer server executable.\n\nIf a path is not specified, then the integrated WebAssembly based server is used by default."
-					},
-					"p4-analyzer.server.logPath": {
-						"type": "string",
-						"scope": "window",
-						"default": null,
-						"markdownDescription": "The optional `'--logpath'` argument to supply to the P4 Analyzer server executable.\n\nUsed only in conjunction with *Absolute Server Path*."
-					},
-					"p4-analyzer.server.logLevel": {
-						"type": "string",
-						"scope": "window",
-						"default": "warn",
-						"enum": [
-							"trace",
-							"debug",
-							"info",
-							"warn",
-							"error"
-						],
-						"markdownDescription": "The optional `'--loglevel'` argument to supply to the P4 Analyzer server executable.\n\nUsed only in conjunction with *Absolute Server Path*."
-					},
-					"p4-analyzer.trace.server": {
-						"type": "string",
-						"scope": "window",
-						"enum": [
-								"off",
-								"messages",
-								"verbose"
-						],
-						"enumDescriptions": [
-								"No trace output",
-								"Trace message only",
-								"Trace message and additional trace properties"
-						],
-						"default": "off",
-						"description": "Specifies the Trace setting of the P4 Analyzer (this is usually overly verbose and not recommended for regular use)."
-				}
-				}
-			}
-		],
-		"languages": [
-			{
-				"id": "p4",
-				"aliases": [
-					"P4"
-				],
-				"extensions": [
-					".p4"
-				],
-				"configuration": "./p4.json"
-			}
-		],
-		"grammars": [
-			{
-				"language": "p4",
-				"scopeName": "source.p4",
-				"path": "./p4.tmLanguage"
-			}
-		]
-	}
+  "name": "p4-analyzer-vscode",
+  "version": "0.0.1-25a3cdd6",
+  "displayName": "P4 Analyzer",
+  "description": "P4 language support for Visual Studio Code",
+  "private": true,
+  "scripts": {
+    "vscode:prepublish": "npm run build-base -- --minify",
+    "bundle-wasm-analyzer": "node git_commit.js && run-script-os",
+    "bundle-wasm-analyzer:nix": "mkdir -p ./node_modules/p4-analyzer-$npm_package_version && cp -R ../p4-analyzer/package.json ../p4-analyzer/lib ./node_modules/p4-analyzer-$npm_package_version",
+    "bundle-wasm-analyzer:windows": "mkdir .\\node_modules\\p4-analyzer-%npm_package_version% & xcopy /E /Y ..\\p4-analyzer\\package.json .\\node_modules\\p4-analyzer-%npm_package_version%\\ & xcopy /E /Y ..\\p4-analyzer\\lib .\\node_modules\\p4-analyzer-%npm_package_version%\\lib\\",
+    "build-base": "esbuild ./src/index.ts --bundle --outfile=lib/index.js --external:vscode --format=cjs --platform=node",
+    "prebuild-base": "npm run bundle-wasm-analyzer",
+    "build": "npm run build-base -- --sourcemap",
+    "build-windows": "npm run build-base -- --sourcemap",
+    "build-nix": "npm run build-base -- --sourcemap",
+    "build-watch": "npm run build-base -- --sourcemap --watch",
+    "package": "node git_commit.js && npx vsce package"
+  },
+  "icon": "p4.png",
+  "releaseTag": null,
+  "publisher": "P4.org",
+  "repository": {
+    "url": "https://github.com/p4lang/p4analyzer.git",
+    "type": "git"
+  },
+  "homepage": "https://www.p4.org",
+  "license": "Apache-2.0",
+  "keywords": [
+    "p4"
+  ],
+  "categories": [
+    "Programming Languages"
+  ],
+  "engines": {
+    "vscode": "^1.73.0"
+  },
+  "main": "./lib/index.js",
+  "activationEvents": [
+    "onLanguage:p4"
+  ],
+  "contributes": {
+    "configuration": [
+      {
+        "title": "P4 Analyzer",
+        "properties": {
+          "p4-analyzer.server.absoluteServerPath": {
+            "type": "string",
+            "scope": "window",
+            "default": null,
+            "markdownDescription": "Specifies the absolute path to a P4 Analyzer server executable.\n\nIf a path is not specified, then the integrated WebAssembly based server is used by default."
+          },
+          "p4-analyzer.server.logPath": {
+            "type": "string",
+            "scope": "window",
+            "default": null,
+            "markdownDescription": "The optional `'--logpath'` argument to supply to the P4 Analyzer server executable.\n\nUsed only in conjunction with *Absolute Server Path*."
+          },
+          "p4-analyzer.server.logLevel": {
+            "type": "string",
+            "scope": "window",
+            "default": "warn",
+            "enum": [
+              "trace",
+              "debug",
+              "info",
+              "warn",
+              "error"
+            ],
+            "markdownDescription": "The optional `'--loglevel'` argument to supply to the P4 Analyzer server executable.\n\nUsed only in conjunction with *Absolute Server Path*."
+          },
+          "p4-analyzer.trace.server": {
+            "type": "string",
+            "scope": "window",
+            "enum": [
+              "off",
+              "messages",
+              "verbose"
+            ],
+            "enumDescriptions": [
+              "No trace output",
+              "Trace message only",
+              "Trace message and additional trace properties"
+            ],
+            "default": "off",
+            "description": "Specifies the Trace setting of the P4 Analyzer (this is usually overly verbose and not recommended for regular use)."
+          }
+        }
+      }
+    ],
+    "languages": [
+      {
+        "id": "p4",
+        "aliases": [
+          "P4"
+        ],
+        "extensions": [
+          ".p4"
+        ],
+        "configuration": "./p4.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "p4",
+        "scopeName": "source.p4",
+        "path": "./p4.tmLanguage"
+      }
+    ]
+  }
 }

--- a/packages/p4-analyzer/package.json
+++ b/packages/p4-analyzer/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "p4-analyzer",
-	"version": "0.0.0",
 	"description": "A WebAssembly based LSP compliant P4 analyzer.",
 	"main": "./lib/index.js",
 	"bin": {


### PR DESCRIPTION
For issue #11 

Whenever a version update happens, all that needs to change is the new `git_commit.js` file version number.

Instead of using number of commits to head `git rev-list --count HEAD`, I chose first 8 characters of commit (Linux builds does the same). If it was number of commits from HEAD, I thought there might be duplicates if we do a commit fixup or reverts of main. 