### PR TITLE
Update Build to incorporate version number in Rust and Node.js Packages

### DIFF
--- a/crates/p4-analyzer/src/cli/flags.rs
+++ b/crates/p4-analyzer/src/cli/flags.rs
@@ -5,13 +5,15 @@ xflags::xflags! {
 
 	/// A Language Server Protocol (LSP) implementation for the P4 programming
 	/// language (see https://p4.org).
-	///
 	cmd p4-analyzer {
 		/// Optional path to a folder where a log file will be written.
 		optional --logpath path: PathBuf
 
 		/// Optional log level to apply when writing to the log file. Defaults to 'debug'.
 		optional --loglevel level: String
+
+		///  Displays the version number.
+		optional -v,--version
 
 		/// Starts executing the LSP server (default command).
 		default cmd server {
@@ -25,29 +27,36 @@ xflags::xflags! {
 // Run `env UPDATE_XFLAGS=1 cargo build` to regenerate.
 #[derive(Debug)]
 pub struct P4Analyzer {
-	pub logpath: Option<PathBuf>,
-	pub loglevel: Option<String>,
-	pub subcommand: P4AnalyzerCmd,
+    pub logpath: Option<PathBuf>,
+    pub loglevel: Option<String>,
+    pub version: bool,
+    pub subcommand: P4AnalyzerCmd,
 }
 
 #[derive(Debug)]
 pub enum P4AnalyzerCmd {
-	Server(Server),
+    Server(Server),
 }
 
 #[derive(Debug)]
 pub struct Server {
-	pub stdio: bool,
+    pub stdio: bool,
 }
 
 impl P4Analyzer {
-	#[allow(dead_code)]
-	pub fn from_env_or_exit() -> Self { Self::from_env_or_exit_() }
+    #[allow(dead_code)]
+    pub fn from_env_or_exit() -> Self {
+        Self::from_env_or_exit_()
+    }
 
-	#[allow(dead_code)]
-	pub fn from_env() -> xflags::Result<Self> { Self::from_env_() }
+    #[allow(dead_code)]
+    pub fn from_env() -> xflags::Result<Self> {
+        Self::from_env_()
+    }
 
-	#[allow(dead_code)]
-	pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> { Self::from_vec_(args) }
+    #[allow(dead_code)]
+    pub fn from_vec(args: Vec<std::ffi::OsString>) -> xflags::Result<Self> {
+        Self::from_vec_(args)
+    }
 }
 // generated end

--- a/crates/p4-analyzer/src/main.rs
+++ b/crates/p4-analyzer/src/main.rs
@@ -31,6 +31,13 @@ use tracing_appender::{
 pub async fn main() {
 	match P4Analyzer::from_env() {
 		Ok(cmd) => {
+			// If the `version` option is set, then simply display the version number and exit.
+			if cmd.version {
+				println!(env!("CARGO_PKG_VERSION"));
+
+				return;
+			}
+
 			let default_logging_layer = create_default_logging_layer::<Registry>(&cmd);
 			let mut layers = if let Some((layer, _)) = default_logging_layer { vec![layer] } else { vec![] };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@nrwl/workspace": "~15.5",
 				"@types/node": "^16",
 				"@types/vscode": "^1",
+				"@types/webpack": "~5.28",
 				"@vscode/vsce": "^2.19.0",
 				"esbuild": "latest",
 				"run-script-os": "^1.1.6",
@@ -376,6 +377,64 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/set-array": "^1.0.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+			"integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.0",
+				"@jridgewell/trace-mapping": "^0.3.9"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.18",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+			"integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "3.1.0",
+				"@jridgewell/sourcemap-codec": "1.4.14"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -539,6 +598,38 @@
 				"typescript": "^3 || ^4"
 			}
 		},
+		"node_modules/@types/eslint": {
+			"version": "8.40.0",
+			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.0.tgz",
+			"integrity": "sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "*",
+				"@types/json-schema": "*"
+			}
+		},
+		"node_modules/@types/eslint-scope": {
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"dev": true,
+			"dependencies": {
+				"@types/eslint": "*",
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
+			"dev": true
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true
+		},
 		"node_modules/@types/node": {
 			"version": "16.18.31",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
@@ -550,6 +641,17 @@
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz",
 			"integrity": "sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==",
 			"dev": true
+		},
+		"node_modules/@types/webpack": {
+			"version": "5.28.1",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-5.28.1.tgz",
+			"integrity": "sha512-qw1MqGZclCoBrpiSe/hokSgQM/su8Ocpl3L/YHE0L6moyaypg4+5F7Uzq7NgaPKPxUxUbQ4fLPLpDWdR27bCZw==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"tapable": "^2.2.0",
+				"webpack": "^5"
+			}
 		},
 		"node_modules/@vscode/vsce": {
 			"version": "2.19.0",
@@ -659,6 +761,164 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@webassemblyjs/ast": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+			"integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/helper-numbers": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+			}
+		},
+		"node_modules/@webassemblyjs/floating-point-hex-parser": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+			"integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-api-error": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+			"integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-buffer": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+			"integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-numbers": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+			"integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/floating-point-hex-parser": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@webassemblyjs/helper-wasm-bytecode": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+			"integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/helper-wasm-section": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+			"integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6"
+			}
+		},
+		"node_modules/@webassemblyjs/ieee754": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+			"integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+			"dev": true,
+			"dependencies": {
+				"@xtuc/ieee754": "^1.2.0"
+			}
+		},
+		"node_modules/@webassemblyjs/leb128": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+			"integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+			"dev": true,
+			"dependencies": {
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@webassemblyjs/utf8": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+			"integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
+			"dev": true
+		},
+		"node_modules/@webassemblyjs/wasm-edit": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+			"integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/helper-wasm-section": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-opt": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6",
+				"@webassemblyjs/wast-printer": "1.11.6"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-gen": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+			"integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-opt": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+			"integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-buffer": "1.11.6",
+				"@webassemblyjs/wasm-gen": "1.11.6",
+				"@webassemblyjs/wasm-parser": "1.11.6"
+			}
+		},
+		"node_modules/@webassemblyjs/wasm-parser": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+			"integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.11.6",
+				"@webassemblyjs/helper-api-error": "1.11.6",
+				"@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+				"@webassemblyjs/ieee754": "1.11.6",
+				"@webassemblyjs/leb128": "1.11.6",
+				"@webassemblyjs/utf8": "1.11.6"
+			}
+		},
+		"node_modules/@webassemblyjs/wast-printer": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+			"integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
+			"dev": true,
+			"dependencies": {
+				"@webassemblyjs/ast": "1.11.6",
+				"@xtuc/long": "4.2.2"
+			}
+		},
+		"node_modules/@xtuc/ieee754": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true
+		},
+		"node_modules/@xtuc/long": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true
+		},
 		"node_modules/@yarnpkg/lockfile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -710,6 +970,52 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.8.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+			"integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-import-assertions": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+			"integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+			"dev": true,
+			"peerDependencies": {
+				"acorn": "^8"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.12.6",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-keywords": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true,
+			"peerDependencies": {
+				"ajv": "^6.9.1"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -869,6 +1175,34 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browserslist": {
+			"version": "4.21.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+			"integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				}
+			],
+			"dependencies": {
+				"caniuse-lite": "^1.0.30001449",
+				"electron-to-chromium": "^1.4.284",
+				"node-releases": "^2.0.8",
+				"update-browserslist-db": "^1.0.10"
+			},
+			"bin": {
+				"browserslist": "cli.js"
+			},
+			"engines": {
+				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
 		"node_modules/buffer": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -902,6 +1236,12 @@
 				"node": "*"
 			}
 		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -914,6 +1254,26 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/caniuse-lite": {
+			"version": "1.0.30001489",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001489.tgz",
+			"integrity": "sha512-x1mgZEXK8jHIfAxm+xgdpHpk50IN3z3q3zP261/WS+uvePxW8izXuCu6AHz0lkuYTlATDehiZ/tNyYBdSQsOUQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			]
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -1002,6 +1362,15 @@
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true,
 			"optional": true
+		},
+		"node_modules/chrome-trace-event": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0"
+			}
 		},
 		"node_modules/cli-cursor": {
 			"version": "3.1.0",
@@ -1249,6 +1618,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/electron-to-chromium": {
+			"version": "1.4.404",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.404.tgz",
+			"integrity": "sha512-te57sWvQdpxmyd1GiswaodKdXdPgn9cN4ht8JlNa04QgtrfnUdWEo1261rY2vaC6TKaiHn0E7QerJWPKFCvMVw==",
+			"dev": true
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1262,6 +1637,19 @@
 			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
+			}
+		},
+		"node_modules/enhanced-resolve": {
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
+			"integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"tapable": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/enquirer": {
@@ -1287,6 +1675,12 @@
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
+		},
+		"node_modules/es-module-lexer": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.2.1.tgz",
+			"integrity": "sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==",
+			"dev": true
 		},
 		"node_modules/esbuild": {
 			"version": "0.17.19",
@@ -1343,6 +1737,28 @@
 				"node": ">=0.8.0"
 			}
 		},
+		"node_modules/eslint-scope": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/eslint-scope/node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1368,6 +1784,18 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
 		"node_modules/estraverse": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
@@ -1375,6 +1803,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.x"
 			}
 		},
 		"node_modules/expand-template": {
@@ -1386,6 +1823,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.2.7",
@@ -1402,6 +1845,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
@@ -1626,6 +2075,12 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/glob-to-regexp": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
@@ -1869,6 +2324,35 @@
 				"node": "*"
 			}
 		},
+		"node_modules/jest-worker": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+			"dev": true,
+			"dependencies": {
+				"@types/node": "*",
+				"merge-stream": "^2.0.0",
+				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/supports-color": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1880,6 +2364,18 @@
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
 			}
+		},
+		"node_modules/json-parse-even-better-errors": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -1957,6 +2453,15 @@
 				"uc.micro": "^1.0.1"
 			}
 		},
+		"node_modules/loader-runner": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.11.5"
+			}
+		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -1997,6 +2502,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
 			"integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+			"dev": true
+		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true
 		},
 		"node_modules/merge2": {
@@ -2116,6 +2627,12 @@
 			"dev": true,
 			"optional": true
 		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true
+		},
 		"node_modules/node-abi": {
 			"version": "3.40.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
@@ -2161,6 +2678,12 @@
 				"node-gyp-build-optional": "optional.js",
 				"node-gyp-build-test": "build-test.js"
 			}
+		},
+		"node_modules/node-releases": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.11.tgz",
+			"integrity": "sha512-+M0PwXeU80kRohZ3aT4J/OnR+l9/KD2nVLNNoRgFtnf+umQVFdGBAO2N8+nCnEi0xlh/Wk3zOGC+vNNx+uM79Q==",
+			"dev": true
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -2379,6 +2902,12 @@
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"dev": true
 		},
+		"node_modules/picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2435,6 +2964,15 @@
 				"once": "^1.3.1"
 			}
 		},
+		"node_modules/punycode": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/qs": {
 			"version": "6.11.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
@@ -2469,6 +3007,15 @@
 					"url": "https://feross.org/support"
 				}
 			]
+		},
+		"node_modules/randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "^5.1.0"
+			}
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
@@ -2648,6 +3195,24 @@
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true
 		},
+		"node_modules/schema-utils": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
+			"integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+			"dev": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.8",
+				"ajv": "^6.12.5",
+				"ajv-keywords": "^3.5.2"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			}
+		},
 		"node_modules/semver": {
 			"version": "7.3.4",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
@@ -2661,6 +3226,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/serialize-javascript": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+			"dev": true,
+			"dependencies": {
+				"randombytes": "^2.1.0"
 			}
 		},
 		"node_modules/side-channel": {
@@ -2728,6 +3302,25 @@
 				"decompress-response": "^6.0.0",
 				"once": "^1.3.1",
 				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
 			}
 		},
 		"node_modules/sprintf-js": {
@@ -2819,6 +3412,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/tapable": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/tar-fs": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -2847,6 +3449,64 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/terser": {
+			"version": "5.17.6",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.17.6.tgz",
+			"integrity": "sha512-V8QHcs8YuyLkLHsJO5ucyff1ykrLVsR4dNnS//L5Y3NiSXpbK1J+WMVUs67eI0KTxs9JtHhgEQpXQVHlHI92DQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.2",
+				"acorn": "^8.5.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/terser-webpack-plugin": {
+			"version": "5.3.9",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
+			"integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "^0.3.17",
+				"jest-worker": "^27.4.5",
+				"schema-utils": "^3.1.1",
+				"serialize-javascript": "^6.0.1",
+				"terser": "^5.16.8"
+			},
+			"engines": {
+				"node": ">= 10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"uglify-js": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"node_modules/through": {
 			"version": "2.3.8",
@@ -2965,6 +3625,45 @@
 				"node": ">= 10.0.0"
 			}
 		},
+		"node_modules/update-browserslist-db": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+			"integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/browserslist"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"escalade": "^3.1.1",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"update-browserslist-db": "cli.js"
+			},
+			"peerDependencies": {
+				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
 		"node_modules/url-join": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -3031,6 +3730,75 @@
 			"version": "3.17.2",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
 			"integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+		},
+		"node_modules/watchpack": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+			"dev": true,
+			"dependencies": {
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/webpack": {
+			"version": "5.83.1",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.83.1.tgz",
+			"integrity": "sha512-TNsG9jDScbNuB+Lb/3+vYolPplCS3bbEaJf+Bj0Gw4DhP3ioAflBb1flcRt9zsWITyvOhM96wMQNRWlSX52DgA==",
+			"dev": true,
+			"dependencies": {
+				"@types/eslint-scope": "^3.7.3",
+				"@types/estree": "^1.0.0",
+				"@webassemblyjs/ast": "^1.11.5",
+				"@webassemblyjs/wasm-edit": "^1.11.5",
+				"@webassemblyjs/wasm-parser": "^1.11.5",
+				"acorn": "^8.7.1",
+				"acorn-import-assertions": "^1.7.6",
+				"browserslist": "^4.14.5",
+				"chrome-trace-event": "^1.0.2",
+				"enhanced-resolve": "^5.14.0",
+				"es-module-lexer": "^1.2.1",
+				"eslint-scope": "5.1.1",
+				"events": "^3.2.0",
+				"glob-to-regexp": "^0.4.1",
+				"graceful-fs": "^4.2.9",
+				"json-parse-even-better-errors": "^2.3.1",
+				"loader-runner": "^4.2.0",
+				"mime-types": "^2.1.27",
+				"neo-async": "^2.6.2",
+				"schema-utils": "^3.1.2",
+				"tapable": "^2.1.1",
+				"terser-webpack-plugin": "^5.3.7",
+				"watchpack": "^2.4.0",
+				"webpack-sources": "^3.2.3"
+			},
+			"bin": {
+				"webpack": "bin/webpack.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependenciesMeta": {
+				"webpack-cli": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webpack-sources": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"esbuild": "latest",
 		"run-script-os": "^1.1.6",
 		"typescript": "^4",
-		"@vscode/vsce": "^2.19.0"
+		"@vscode/vsce": "^2.19.0",
+		"@types/webpack": "~5.28"
 	}
 }

--- a/packages/p4-analyzer-vscode/project.json
+++ b/packages/p4-analyzer-vscode/project.json
@@ -5,5 +5,17 @@
 	"implicitDependencies": [
 		"p4-analyzer"
 	],
-	"includedScripts": ["build", "package"]
+	"includedScripts": ["build", "package"],
+	"targets": {
+		"set-version": {
+			"executor": "./tools:version",
+			"options": {
+				"packages": [
+					"package.json",
+					"../p4-analyzer/package.json",
+					"../../crates/p4-analyzer/Cargo.toml"
+				]
+			}
+		}
+	}
 }

--- a/tools/executors.json
+++ b/tools/executors.json
@@ -1,0 +1,9 @@
+{
+	"executors": {
+		"version": {
+			"implementation": "./lib/version.js",
+			"schema": "./version_schema.json",
+			"description": "Updates the version number of crates and packages in the Workspace."
+		}
+	}
+}

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,0 +1,3 @@
+{
+	"executors": "./executors.json"
+}

--- a/tools/src/jsonUtils.ts
+++ b/tools/src/jsonUtils.ts
@@ -1,0 +1,10 @@
+import { readJsonFile, writeJsonFile } from "@nrwl/devkit";
+
+export function writePackageJson(filePath: string, version: string) {
+	const json = readJsonFile(filePath);
+
+	json["version"] = version;
+
+	writeJsonFile(filePath, json);
+}
+

--- a/tools/src/version.ts
+++ b/tools/src/version.ts
@@ -1,0 +1,134 @@
+import { ExecutorContext, logger, readJsonFile } from "@nrwl/devkit";
+import { execSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { writePackageJson } from "./jsonUtils";
+
+const SemVerRegEx = /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-(?<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+interface Options {
+	local?: boolean;
+	packages: string[];
+}
+
+/**
+ * Retrieves the current tag for HEAD.
+ *
+ * @returns The current tag if one is on HEAD; otherwise `undefined`.
+ */
+export function getCurrentTag(): string | undefined {
+  try {
+    return execSync(`git describe --exact-match HEAD`, { stdio: "ignore" }).toString().trim()
+  }
+  catch(err) {
+    return undefined;
+  }
+}
+
+/**
+ * Retrieves the commit hash of HEAD, or a specified file.
+ *
+ * @param filePath - The optional file path for which a commit hash is required.
+ * @returns The commit hash of `filePath`; or the commit hash of HEAD if `filePath` is `undefined`.
+ */
+export function getLatestCommit(filePath?: string): string {
+  try {
+    return filePath
+      ? execSync(`git log --format=%h -1 -- ${filePath}`).toString().trim()
+      : execSync("git log --format=%h -1").toString().trim()
+  }
+  catch(err) {
+    throw new Error("Failed to retrieve the latest commit.");
+  }
+}
+
+/**
+ * Retrieves the current branch name.
+ *
+ * @returns The current branch name.
+ */
+export function getCurrentBranch(): string | undefined {
+  try {
+    return execSync(`git rev-parse --abbrev-ref HEAD`).toString().trim()
+  }
+  catch(err) {
+    throw new Error("Failed to retrieve the current branch name.");
+  }
+}
+
+/**
+ * Computes and returns a valid semantic version based on the content of the `version.json` file in the
+ * workspace root, the git height since the file was last updated, and the commit hash if the current branch is
+ * not designated as a branch that packages should be released from.
+ *
+ * @param rootDir - The path representing the workspace root.
+ * @param local When `true`, forces the returned version to be based on the current commit identifier.
+ * @returns A string representing the computed version.
+ */
+export function getVersion(context: ExecutorContext, local: boolean = false): string {
+  const currentTag = getCurrentTag();
+  const currentTagVersionParts = SemVerRegEx.exec(currentTag)?.groups;
+
+  if(currentTagVersionParts) return currentTag;
+
+  const versionInfoFile = join(context.root, "version.json");
+  const versionFileCommit = getLatestCommit(versionInfoFile);
+
+  if(!versionFileCommit) {
+    logger.warn("Unable to determine a valid version. The 'version.json' file is not part of the working tree.");
+
+    return "0.0.0";
+  }
+
+  const versionInfo = readJsonFile(versionInfoFile);
+  const versionParts = SemVerRegEx.exec(versionInfo.version)?.groups;
+
+  if(!versionParts) {
+  	logger.fatal(`The 'version.json' file is invalid. '${versionInfo.version}' is an invalid version number.`);
+
+    return "0.0.0";
+  }
+
+  const currentBranchName = getCurrentBranch();
+
+  if(versionInfo.releaseBranches.find((releaseBranch) => currentBranchName.startsWith(releaseBranch)) && !local) {
+    const gitHeight = Number((execSync(`git log --format=%h ${versionFileCommit}.. | wc -l`)).toString().trim()) + 1;
+
+    return `${versionInfo.version}.${gitHeight}`;
+  }
+
+  const commitId = getLatestCommit();
+
+  return `${versionInfo.version}-g${commitId}`;
+}
+
+/**
+ * An Nx executor that updates the Rust crate and Node.js packages that are present in the current
+ * workspace.
+ */
+export default async function versionPackagesExecutor(options: Options, context: ExecutorContext) {
+	const version = getVersion(context);
+	const projectRoot = join(
+		context.root,
+		context.workspace.projects[context.projectName].root);
+
+	for (const packageTarget of options.packages) {
+		const packageTargetPath = resolve(projectRoot, packageTarget);
+
+		logger.info(`Setting '${packageTargetPath}' to version '${version}'.`);
+
+		if (packageTargetPath.endsWith("/package.json")) {
+			writePackageJson(packageTargetPath, version);
+		}
+		else if (packageTargetPath.endsWith("/Cargo.toml")) {
+			// TODO: Read and write the .toml file
+		}
+		else {
+			logger.fatal(`Unsupported package target: '${packageTargetPath}'.`);
+		}
+	}
+
+	return {
+		success: true
+	}
+}
+

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"sourceMap": true,
+		"rootDir": "src",
+		"outDir": "lib",
+		"declaration": false,
+		"target": "ES2021",
+		"lib": [
+			"ES2021"
+		],
+		"module": "CommonJS"
+	},
+	"include": [
+		"src/**/*"
+	]
+}

--- a/tools/version_schema.json
+++ b/tools/version_schema.json
@@ -1,0 +1,21 @@
+{
+  "title": "Version",
+  "description": "Sets a version number in the current set of Rust crates and Node.js packages.",
+  "cli": "nx",
+  "type": "object",
+  "properties": {
+    "local": {
+      "type": "boolean",
+      "description": "Forces the version to be based on the current commit.",
+      "default": false
+    },
+		"packages": {
+			"type": "array",
+			"description": "The collection of path 'globs' identifying the 'package.json' or 'Cargo.toml' files to update.",
+			"items": {
+				"type": "string"
+			}
+		}
+  },
+  "required": ["packages"]
+}

--- a/version.json
+++ b/version.json
@@ -1,0 +1,7 @@
+{
+	"version": "1.0.0-preview",
+	"releaseBranches": [
+		"master",
+		"release/"
+	]
+}


### PR DESCRIPTION
This PR implements #11 by adding a custom Nx Executor that will first compute a _SemVer_ compatible version number; and then use it to update the appropriate `'package.json'` and `'Cargo.toml'` files.

The version number is based on the major and minor values defined in a new `'version.json'` file that is present in the root of the repository. This file will be used to control the _product version_ that we require a build for, while the Nx Executor will suffix the version with either: a) the commit height for _releasable_ branches, or b) the current commit id for all other branches.