### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    # Specify labels for github-actions pull requests
+    labels:
+      - "infrastructure"
+    # Bundle updates into a single PR.
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Configure Dependabot for GitHub Actions updates with weekly schedule and specific labels.